### PR TITLE
Remove redundant "for emacs" from package description

### DIFF
--- a/spacegray-theme.el
+++ b/spacegray-theme.el
@@ -1,4 +1,4 @@
-;;; spacegray-theme.el --- A Hyperminimal UI Theme for Emacs
+;;; spacegray-theme.el --- A Hyperminimal UI Theme
 
 ;; Copyright (C) 2013 Bruce Williams
 


### PR DESCRIPTION
Just a quick tweak while merging https://github.com/milkypostman/melpa/pull/1320

P.S. I recognise most of the code here: the `afternoon` theme was based on my `tomorrow` themes... :-)
