### PR TITLE
Add theming for Helm

### DIFF
--- a/spacegray-theme.el
+++ b/spacegray-theme.el
@@ -588,7 +588,19 @@
    `(term-color-blue    ((,class (:foreground ,blue :background ,blue))))
    `(term-color-magenta ((,class (:foreground ,purple :background ,purple))))
    `(term-color-cyan    ((,class (:foreground ,aqua :background ,aqua))))
-   `(term-color-white   ((,class (:foreground ,background :background ,background)))))
+   `(term-color-white   ((,class (:foreground ,background :background ,background))))
+
+   ;; helm
+   `(helm-buffer-saved-out ((,class (:inherit warning))))
+   `(helm-buffer-size ((,class (:foreground ,yellow))))
+   `(helm-buffer-not-saved ((,class (:foreground ,orange))))
+   `(helm-buffer-process ((,class (:foreground ,aqua))))
+   `(helm-buffer-directory ((,class (:foreground ,blue))))
+   `(helm-ff-directory ((,class (:foreground ,aqua))))
+   `(helm-candidate-number ((,class (:foreground ,red))))
+   `(helm-selection ((,class (:inherit highlight))))
+   `(helm-separator ((,class (:foreground ,purple))))
+   `(helm-source-header ((,class (:weight bold :foreground ,orange :height 1.25)))))
 
   (custom-theme-set-variables
    'spacegray


### PR DESCRIPTION
Support for Helm was missing, so this should fix most of the ugliness.

All credit goes to Steve Purcell (@purcell) for the relevant lines in his [Tomorrow theme](https://github.com/purcell/color-theme-sanityinc-tomorrow/blob/master/color-theme-sanityinc-tomorrow.el#L422-L432).